### PR TITLE
don't submit an event if asked not to via environment variable

### DIFF
--- a/gnu_linux/home/lg/bin/lg-relaunch
+++ b/gnu_linux/home/lg/bin/lg-relaunch
@@ -77,10 +77,12 @@ else
 fi
 
 if [ -f ~/bin/lg-submit-event ]; then
-  ~/bin/lg-submit-event -t lg-relaunch \
-    -w "Manually relaunched $(hostname)"\
-    -d "uptime = $(uptime) \n \
-    ${USER}"
+  if [ "${NO_EVENT_PLEASE}" != "" ]; then
+    ~/bin/lg-submit-event -t lg-relaunch \
+      -w "Manually relaunched $(hostname)"\
+      -d "uptime = $(uptime) \n \
+      ${USER}"
+  fi
 fi
 
 if [ -f ~/bin/flowdock_event ]; then


### PR DESCRIPTION
Some external programs that call lg-relaunch will take care of their
own submitting of events.
